### PR TITLE
Upgrade httpclient and lastaflute libraries version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /build
 /bin
 .DS_Store
+.java-version
 
 # IntelliJ IDEA
 /.idea/*

--- a/pom.xml
+++ b/pom.xml
@@ -106,18 +106,18 @@
 								<pluginExecution>
 									<pluginExecutionFilter>
 										<groupId>org.apache.maven.plugins</groupId>
-                        				<artifactId>maven-enforcer-plugin</artifactId>
-                        				<versionRange>[1.0.0,)</versionRange>
-                        				<goals>
-                           					<goal>enforce</goal>
-                        				</goals>
-                    				</pluginExecutionFilter>
-                    				<action><ignore /></action>
-                				</pluginExecution>
-                			</pluginExecutions>
-                		</lifecycleMappingMetadata>
-                	</configuration>
-                </plugin>
+										<artifactId>maven-enforcer-plugin</artifactId>
+										<versionRange>[1.0.0,)</versionRange>
+										<goals>
+						   					<goal>enforce</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action><ignore /></action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -165,30 +165,30 @@
 			 'xxx.jar.asc' file can be created by this plug-in
 			 you can deploy by 'mvn -e clean deploy -Dgpg.keyname=xxx -Dgpg.passphrase="xxx"'
 			 -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>6.0.3</version>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>6.0.3</version>
 				<configuration>
 					<failBuildOnCVSS>4</failBuildOnCVSS>
-                    <skipProvidedScope>true</skipProvidedScope>
-                    <skipRuntimeScope>true</skipRuntimeScope>
-                    <format>ALL</format>
-                </configuration>
+					<skipProvidedScope>true</skipProvidedScope>
+					<skipRuntimeScope>true</skipRuntimeScope>
+					<format>ALL</format>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>
@@ -196,7 +196,7 @@
 						</goals>
 					</execution>
 				</executions>
-            </plugin>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<inceptionYear>2015</inceptionYear>
 
 	<properties>
-		<lastaflute.version>1.2.0</lastaflute.version> <!-- about one year old (from now) -->
+		<lastaflute.version>1.1.4</lastaflute.version> <!-- about one year old (from now) -->
 		<httpclient.version>4.5.13</httpclient.version>
 		<slf4j.version>1.7.12</slf4j.version>
 		<utflute.version>0.9.1</utflute.version>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,19 @@
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>6.0.3</version>
+				<configuration>
+					<failBuildOnCVSS>4</failBuildOnCVSS>
+                    <skipProvidedScope>true</skipProvidedScope>
+                    <skipRuntimeScope>true</skipRuntimeScope>
+                    <format>ALL</format>
+                </configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
             </plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 	<inceptionYear>2015</inceptionYear>
 
 	<properties>
-		<lastaflute.version>1.1.4</lastaflute.version> <!-- about one year old (from now) -->
-		<httpclient.version>4.5.12</httpclient.version>
+		<lastaflute.version>1.2.0</lastaflute.version> <!-- about one year old (from now) -->
+		<httpclient.version>4.5.13</httpclient.version>
 		<slf4j.version>1.7.12</slf4j.version>
 		<utflute.version>0.9.1</utflute.version>
 		<junit.version>4.8.2</junit.version> <!-- latest version without hamcrest -->
@@ -178,6 +178,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>6.0.3</version>
             </plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
lasta-remoteapiで使用している `org.apache.httpcomponents:httpclient:4.5.12` にて脆弱性 [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) が見つかりましたので、バージョンアップ対応を行いました。

- org.apache.httpcomponents:httpclient を 4.5.12 -> 4.15.13
- ~~合わせて org.lastaflute:lastaflute を 1.1.4 -> 1.2.0~~
- 合わせて OWASP dependency check のプラグインを追加

下記は依存関係抜粋
```
...
|    +--- org.dbflute:dbflute-runtime:1.2.2 -> 1.2.3 (*)
|    +--- org.lastaflute:lastaflute:1.1.6 -> 1.2.  (*)
|    +--- org.lastaflute.remoteapi:lasta-remoteapi:0.4.4 -> 0.4.5
|    |    +--- org.lastaflute:lastaflute:1.1.4 -> 1.2.0 (*)
|    |    \--- org.apache.httpcomponents:httpclient:4.5.12
...
```